### PR TITLE
refactor(gulpfile): remove dead watch() function shadowed by var watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -122,10 +122,6 @@ function watchStyles() {
   gulp.watch([ '_sass/*.scss' ], styles);
 }
 
-function watch() {
-  gulp.parallel(watchData, watchMarkup, watchScripts, watchStyles);
-}
-
 var compile = gulp.parallel(styles, stylesVendors, scripts, scriptsVendors);
 var serve = gulp.series(compile, jekyll, browserSyncServe);
 var watch = gulp.parallel(watchData, watchMarkup, watchScripts, watchStyles);


### PR DESCRIPTION
function watch() (calling gulp.parallel without returning/using the result) was immediately overwritten by var watch = gulp.parallel(...) a few lines below, making the function declaration dead code.