### PR TITLE
feat(content): revamp site with current role, timeline, skills and projects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ baseurl: ""
 username: Shantnu Kumar
 # typing_text: This will be typed before 'scroll down for more'.
 # > set this to your job title, e.g. Fullstack Developer
-typing_text: Android and Open Source Enthusiast
+typing_text: Senior Software Engineer
 # email: Your E-Mail address for the email button.
 email: me.shantnu@gmail.com
 # For every social button you want to display, set your username or userid
@@ -34,7 +34,7 @@ show_aboutme_card: true
 # about_me_title: The will be displayed as the title in the About Me section
 about_me_title: About Me
 # about_me_description: This will be displayed under the title.
-about_me_description: I am Shantnu Kumar, a final year undergraduate from the Institute of Engineering and Management, Kolkata. Currently, I am focussed on Android Development and like to dig into Open Source Projects, check my profile <a href="https://sourcerer.io/dipu989" target="_blank">here</a>. I try hard not to break the production code. My technical interest lies in the field of Operating Systems. Linux and Music aficionado!
+about_me_description: I am Shantnu Kumar, a Senior Software Engineer specializing in MDM (Mobile Device Management), backend microservices, and DevOps. I've spent most of my career building device management systems for Android and iOS — first at <a href="https://esper.io" target="_blank">Esper</a> and now at <a href="https://jumpcloud.com" target="_blank">JumpCloud</a> — designing the backend services and native apps behind them. Earlier on, I contributed to <a href="https://fossasia.org" target="_blank">FOSSASIA</a> through Codeheat and mentored students during Google Code-In. I try hard not to break production code. Linux and Music aficionado!
 
 # SKILLS SECTION
 # show_skills_card:

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -13,24 +13,26 @@
 #     - tag: AngularJS
 #     - tag: Node
 
- - name: Tech Feeds
-   descr: "This App will show top tech news in user's feed using HackerNews API. "
-   Demo: https://github.com/dipu989/Tech-Feeds
-   tags:
-     - tag: Android
-     - tag: Java
-     - tag: Hacker News API
+- name: Atmos
+  descr: "Personal environmental telemetry and carbon intelligence backend — tracks activity, computes CO2 emissions, and dedupes GPS/receipt data through an event-driven architecture."
+  demo: https://github.com/dipu989/atmos-core
+  tags:
+    - tag: Go
+    - tag: Fiber
+    - tag: PostgreSQL
+    - tag: GORM
 
- - name: Social Stars
-   descr: "Django Powered web site, focussed on Space related discussions."
-   Demo: https://github.com/dipu989/SocialStars
-   tags:
-     - tag: Python
-     - tag: Django
+- name: Tech Feeds
+  descr: "This App will show top tech news in user's feed using HackerNews API."
+  demo: https://github.com/dipu989/Tech-Feeds
+  tags:
+    - tag: Android
+    - tag: Java
+    - tag: Hacker News API
 
- - name: Weather Application
-   descr: "An application which informs about current location's name, temprature, windspeed, wind-direction and humidity. "
-   Demo: https://github.com/dipu989/Weather-Application
-   tags:
-     - tag: Web
-     - tag: API
+- name: Weather Application
+  descr: "An application which informs about current location's name, temperature, windspeed, wind-direction and humidity."
+  demo: https://github.com/dipu989/Weather-Application
+  tags:
+    - tag: Web
+    - tag: API

--- a/_data/skills-frameworks.yml
+++ b/_data/skills-frameworks.yml
@@ -5,5 +5,8 @@
 # - name: Framework
 #   weight: 5
 
-- name: Django
-  weight: 1
+- name: SwiftUI
+  weight: 4
+
+- name: GORM
+  weight: 4

--- a/_data/skills-frameworks.yml
+++ b/_data/skills-frameworks.yml
@@ -6,7 +6,7 @@
 #   weight: 5
 
 - name: SwiftUI
-  weight: 4
+  weight: 3
 
 - name: GORM
-  weight: 4
+  weight: 3

--- a/_data/skills-languages.yml
+++ b/_data/skills-languages.yml
@@ -5,23 +5,20 @@
 # - name: Language
 #   weight: 5
 
-- name: C++
+- name: Go
   weight: 5
 
-- name: Java
+- name: Swift
   weight: 4
-
-- name: C
-  weight: 2
-
-- name: HTML5
-  weight: 4
-
-- name: Java
-  weight: 1
 
 - name: Kotlin
-  weight: 1
+  weight: 3
+
+- name: Java
+  weight: 3
+
+- name: Python
+  weight: 2
 
 - name: SQL
-  weight: 2
+  weight: 3

--- a/_data/skills-languages.yml
+++ b/_data/skills-languages.yml
@@ -6,10 +6,10 @@
 #   weight: 5
 
 - name: Go
-  weight: 5
+  weight: 3
 
 - name: Swift
-  weight: 4
+  weight: 3
 
 - name: Kotlin
   weight: 3
@@ -18,7 +18,7 @@
   weight: 3
 
 - name: Python
-  weight: 2
+  weight: 3
 
 - name: SQL
   weight: 3

--- a/_data/skills-tools.yml
+++ b/_data/skills-tools.yml
@@ -6,19 +6,19 @@
 #   weight: 5
 
 - name: Git
-  weight: 5
+  weight: 3
 
 - name: PostgreSQL
-  weight: 4
+  weight: 3
 
 - name: Kubernetes
-  weight: 4
+  weight: 3
 
 - name: Docker
-  weight: 4
+  weight: 3
 
 - name: Fastlane
-  weight: 4
+  weight: 3
 
 - name: Kafka
   weight: 3
@@ -30,4 +30,4 @@
   weight: 3
 
 - name: MongoDB
-  weight: 2
+  weight: 3

--- a/_data/skills-tools.yml
+++ b/_data/skills-tools.yml
@@ -8,14 +8,26 @@
 - name: Git
   weight: 5
 
-- name: Bash
-  weight: 3
-
-- name: Travis CI
-  weight: 1
-
-- name: Android Studio
-  weight: 3
-
-- name: Postman
+- name: PostgreSQL
   weight: 4
+
+- name: Kubernetes
+  weight: 4
+
+- name: Docker
+  weight: 4
+
+- name: Fastlane
+  weight: 4
+
+- name: Kafka
+  weight: 3
+
+- name: ArgoCD
+  weight: 3
+
+- name: Buildkite
+  weight: 3
+
+- name: MongoDB
+  weight: 2

--- a/_data/timeline.yml
+++ b/_data/timeline.yml
@@ -17,29 +17,52 @@
 #     - tag: Rails
 #   timeline-side: right
 
-- title: Google Code In
-  title-url: https://codein.withgoogle.com/archive/
-  date: Dec 2019 - Feb 2020
-  subtitle: Mentor at FOSSASIA
+- title: JumpCloud
+  title-url: https://jumpcloud.com/
+  date: Feb 2025 - Present
+  subtitle: Senior Software Engineer — Apple MDM Team. Migrated Volume Purchase Program APIs to 2.0, built DDM-based OS update management, and lead migration of profile-based workflows to DDM.
   tags:
-    - tag: Web
-    - tag: Bash
-    - tag: Android
+    - tag: Golang
+    - tag: Apple MDM
+    - tag: DDM
   timeline-side: right
 
-- title: Codeheat
-  title-url: https://codeheat.org/
-  date: Sep 2019 - Feb 2020
-  subtitle: Finalist Winner at Codeheat
+- title: Esper
+  title-url: https://esper.io/
+  date: Aug 2021 - Feb 2025
+  subtitle: Senior Software Engineer — built Esper's iOS MDM solution from the ground up, designed device onboarding microservices in Golang, and led development of the Esper iOS app in SwiftUI.
   tags:
-    - tag: Android App Development
+    - tag: Golang
+    - tag: SwiftUI
+    - tag: Kafka
+    - tag: PostgreSQL
+    - tag: Kubernetes
+  timeline-side: left
+
+- title: Infosys
+  title-url: https://www.infosys.com/
+  date: Nov 2020 - Jul 2021
+  subtitle: System Engineer Trainee — Foundation Program training in Java, DBMS, and Linux systems.
+  tags:
+    - tag: Java
+    - tag: DBMS
+    - tag: Linux
   timeline-side: right
+
+- title: FOSSASIA
+  title-url: https://fossasia.org/
+  date: Sep 2019 - Mar 2020
+  subtitle: Open Source Contributor — Google Code-In mentor guiding pre-university students, and contributor to the NeuroLab Android app.
+  tags:
+    - tag: Android
+    - tag: Open Source
+  timeline-side: left
 
 - title: IEM, Kolkata
-  title-url: https://example.com/
-  date: Aug 2016 - Present
-  subtitle: B.Tech Information Technology
-  timeline-side: left
+  title-url: https://iem.edu.in/
+  date: Aug 2016 - May 2020
+  subtitle: B.Tech Information Technology (8.46 CGPA)
+  timeline-side: right
 
 - title: Tata DAV Public School
   title-url: https://example.com/

--- a/_data/timeline.yml
+++ b/_data/timeline.yml
@@ -64,8 +64,8 @@
   subtitle: B.Tech Information Technology (8.46 CGPA)
   timeline-side: right
 
-- title: Tata DAV Public School
-  title-url: https://example.com/
+- title: Tata DAV Public School, Sijua
+  title-url: http://tatadavsijua.org/
   date: Apr 2013 - May 2016
   subtitle: Matriculation and Intermediate
   timeline-side: left

--- a/_includes/section-projects.html
+++ b/_includes/section-projects.html
@@ -8,7 +8,7 @@
         </div>
         <p class="project-desc">{{project.descr}}</p>
         {% if project.demo %}
-          <a class="highlight-link" href="{{project.github}}" target="_blank" rel="noreferrer">
+          <a class="highlight-link" href="{{project.demo}}" target="_blank" rel="noreferrer">
             Demo
           </a>
         {% endif %}


### PR DESCRIPTION
## Summary
- Bio, tagline, timeline, skills, and projects were frozen at a 2020 "final year undergraduate" snapshot. Updated from current resume:
  - **Timeline**: JumpCloud (Feb 2025–Present), Esper (Aug 2021–Feb 2025), Infosys, FOSSASIA, IEM Kolkata (with real end date), Tata DAV School.
  - **Skills**: replaced stale/duplicate entries (Java was listed twice with conflicting weights) with current stack — Go, Swift, Kotlin, Java, Python, SwiftUI, GORM, PostgreSQL, Kubernetes, Docker, Fastlane, Kafka, ArgoCD, Buildkite, MongoDB.
  - **Projects**: kept Tech Feeds and Weather Application, dropped Social Stars, added Atmos (public repo).
  - **Bio**: rewrote `about_me_description` and `typing_text` in `_config.yml` to reflect current Senior Software Engineer / MDM & backend focus instead of undergrad/Android-focused copy.
- Fixed a data-shape bug in `_includes/section-projects.html`: the Demo link checked `project.demo` but linked `href="{{project.github}}"` — neither key existed in `projects.yml` (which used capitalized `Demo:`), so the Demo button silently never rendered on any project card. Normalized the data file to lowercase `demo:` and fixed the template to link `project.demo`.

## Notes for follow-up
- Tata DAV Public School's `title-url` is still a placeholder (`https://example.com/`) — there are multiple schools by that name and I didn't want to guess the wrong one.
- `cv_download_link` in `_config.yml` was left untouched (still the old Google Drive link) — didn't have a new one to swap in.
- Skill weights (1-5) are my best-guess draft based on resume emphasis, not a precise self-assessment — worth a pass to adjust.

## Test plan
- [x] `ruby -ryaml` parse check on all edited YAML files — all valid
- [ ] Full `bundle exec jekyll build` not run locally — this Ruby/arm64 setup can't build the `ffi` native gem (pre-existing env issue, unrelated to this diff)