### PR TITLE
feat(content): swap Weather Application for Tick It

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -30,6 +30,16 @@
     - tag: PostgreSQL
     - tag: GORM
 
+- name: Tick It
+  descr: "A To-Do Android app built with Kotlin and MVVM — add and prioritize tasks, mark them complete, search, and sort by name or date created."
+  links:
+    - label: Link
+      url: https://github.com/dipu989/Tick-It
+  tags:
+    - tag: Kotlin
+    - tag: Android
+    - tag: MVVM
+
 - name: Tech Feeds
   descr: "This App will show top tech news in user's feed using HackerNews API."
   links:
@@ -39,12 +49,3 @@
     - tag: Android
     - tag: Java
     - tag: Hacker News API
-
-- name: Weather Application
-  descr: "An application which informs about current location's name, temperature, windspeed, wind-direction and humidity."
-  links:
-    - label: Link
-      url: https://github.com/dipu989/Weather-Application
-  tags:
-    - tag: Web
-    - tag: API


### PR DESCRIPTION
## Summary
- Replaced the "Weather Application" project card with **Tick It** — a Kotlin/MVVM To-Do Android app ([github.com/dipu989/Tick-It](https://github.com/dipu989/Tick-It), public repo). Description pulled from the repo's README (Room, Dagger Hilt, Navigation Components, Coroutines; add/complete/delete tasks, search, sort by name or date).
- Reordered the projects list to: **Atmos → Tick It → Tech Feeds**.

## Test plan
- [x] `ruby -ryaml` confirms `_data/projects.yml` parses correctly
- [x] Re-rendered the real templates via LiquidJS and verified via DOM query: project order is exactly `["Atmos", "Tick It", "Tech Feeds"]`, Tick It's link points to `https://github.com/dipu989/Tick-It`, and "Weather Application" no longer appears anywhere on the page