### PR TITLE
fix(config): point CV link at the raw PDF instead of Drive's viewer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,7 @@ show_timeline_card: true
 timeline_title: Education & Experience
 # cv_download_link: The link where you host your cv.
 # > e.g. you share your cv on your dropbox, then add the dropbox link here
-cv_download_link: https://drive.google.com/uc?export=download&id=1dtjbzHNw4NZhscbhv8nkf1rwTN35wGRw
+cv_download_link: https://drive.google.com/uc?export=download&id=1dBJ3yy6FpkK6ibu-G8LpHTJujO-RLIGX
 
 # PROJECTS SECTION
 # show_projects_card:

--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,7 @@ show_timeline_card: true
 timeline_title: Education & Experience
 # cv_download_link: The link where you host your cv.
 # > e.g. you share your cv on your dropbox, then add the dropbox link here
-cv_download_link: https://drive.google.com/file/d/1dtjbzHNw4NZhscbhv8nkf1rwTN35wGRw/view?usp=sharing
+cv_download_link: https://drive.google.com/uc?export=download&id=1dtjbzHNw4NZhscbhv8nkf1rwTN35wGRw
 
 # PROJECTS SECTION
 # show_projects_card:


### PR DESCRIPTION
## Summary
`cv_download_link` pointed at Google Drive's HTML viewer page (`/file/d/.../view`). Switched to Drive's direct-file form (`/uc?export=download&id=...`), which resolves straight to the PDF instead of Drive's UI chrome.

Also updated to point at the newly hosted resume file you shared (`1dBJ3yy6FpkK6ibu-G8LpHTJujO-RLIGX`) instead of the older one.

## Test plan
- [x] `curl -I` on the new URL confirms `content-disposition: attachment; filename="Shantnu Resume (Sr Engineer)-3.pdf"` — genuinely serving the PDF file, not a viewer page
- [x] `ruby -ryaml` confirms the URL (which contains an unescaped `&`) still parses correctly as a YAML plain scalar
- [x] Re-rendered the real template via LiquidJS — confirmed the `href` on "curriculum vitae" outputs the new URL correctly